### PR TITLE
feat: EKS → RDS 연결을 위한 SG 구성 및 관련 모듈 수정

### DIFF
--- a/.github/workflows/update-secrets.yml
+++ b/.github/workflows/update-secrets.yml
@@ -1,0 +1,28 @@
+name: Update GitHub Secret
+
+on:
+  workflow_dispatch:
+
+jobs:
+  update-secret:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Terraform Output
+        id: tf_output
+        run: |
+          cd terraform
+          terraform init -input=false
+          terraform output -raw rds_endpoint > endpoint.txt
+          echo "RDS_ENDPOINT=$(cat endpoint.txt)" >> $GITHUB_ENV
+
+      - name: Update GitHub Secret
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          gh secret set DB_HOST -b"$RDS_ENDPOINT" -R <owner>/<repo>

--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -26,11 +26,6 @@ module "route" {
   nat_gateway_id     = module.nat.nat_gateway_id
 }
 
-module "security_group" {
-  source = "../../modules/networking/security_group"
-  vpc_id = module.vpc.vpc_id
-}
-
 module "iam" {
   source = "../../modules/iam"
 }
@@ -85,5 +80,14 @@ module "sql_initializer" {
   ]
 }
 
+# EKS Cluster SG ID를 가져오기 위한 Data Source
+data "aws_eks_cluster" "this" {
+  name = module.eks.cluster_name
+}
 
-
+# 수정된 security_group 모듈 선언: eks_node_sg_id를 변수로 전달
+module "security_group" {
+  source          = "../../modules/networking/security_group"
+  vpc_id          = module.vpc.vpc_id
+  eks_node_sg_id  = data.aws_eks_cluster.this.vpc_config[0].cluster_security_group_id
+}

--- a/modules/eks/lifecycle.tf
+++ b/modules/eks/lifecycle.tf
@@ -1,0 +1,21 @@
+resource "aws_ecr_lifecycle_policy" "spring_app" {
+  repository = "spring-app"
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Delete untagged images older than 1 days"
+        selection = {
+          tagStatus     = "untagged"
+          countType     = "sinceImagePushed"
+          countUnit     = "days"
+          countNumber   = 1
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}

--- a/modules/eks/outputs.tf
+++ b/modules/eks/outputs.tf
@@ -10,3 +10,6 @@ output "cluster_ca" {
   value = aws_eks_cluster.this.certificate_authority[0].data
 }
 
+output "node_group_name" {
+  value = aws_eks_node_group.default.node_group_name
+}

--- a/modules/networking/security_group/security_groups.tf
+++ b/modules/networking/security_group/security_groups.tf
@@ -41,3 +41,13 @@ resource "aws_security_group" "rds_sg" {
     Name = "rds-sg"
   }
 }
+
+resource "aws_security_group_rule" "allow_eks_app_to_rds" {
+  type                     = "ingress"
+  from_port                = 3306
+  to_port                  = 3306
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.rds_sg.id
+  source_security_group_id = var.eks_node_sg_id
+  description              = "Allow EKS app access to RDS"
+}

--- a/modules/networking/security_group/variables.tf
+++ b/modules/networking/security_group/variables.tf
@@ -1,3 +1,8 @@
 variable "vpc_id" {
   type = string
 }
+
+variable "eks_node_sg_id" {
+  description = "SG ID of EKS Node Group (cluster SG)"
+  type        = string
+}


### PR DESCRIPTION
- RDS 보안 그룹에 EKS Node SG 접근 허용 룰 추가
- eks 모듈에 cluster_name, node_group_name 출력 추가
- security_group 모듈에 eks_node_sg_id 변수 추가
- dev/main.tf에서 eks SG ID를 data source로 가져와 보안 그룹 모듈에 전달
- 워크플로우 secrets 업데이트용 yaml 추가
- eks/lifecycle.tf 초기화