### PR TITLE
fix: grafana 서비스 타입을 LoadBalancer에서 ClusterIP로 변경

### DIFF
--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -230,7 +230,7 @@ resource "helm_release" "grafana" {
 
   set {
     name  = "service.type"
-    value = "LoadBalancer"
+    value = "ClusterIP"
   }
 }
 


### PR DESCRIPTION
- Ingress 기반 외부 노출 구조로 전환을 위해 grafana Helm 릴리스의 서비스 타입 수정
- 중복 ELB 생성을 방지하고 인프라 정리를 위한 조치