### PR TITLE
feat(monitoring): IRSA 기반 Grafana CloudWatch 연동 구성 및 OIDC 출력 추가

### DIFF
--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -199,19 +199,6 @@ module "monitoring" {
 # EKS 클러스터 정보 주입용 데이터 소스
 # ─────────────────────────────
 
-provider "helm" {
-  kubernetes = {
-    host                   = module.eks.cluster_endpoint
-    cluster_ca_certificate = base64decode(module.eks.cluster_ca_data)
-
-    exec = {
-      api_version = "client.authentication.k8s.io/v1beta1"
-      command     = "aws"
-      args        = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
-    }
-  }
-}
-
 resource "helm_release" "kube_prometheus_stack" {
   name             = "kube-prometheus-stack"
   repository       = "https://prometheus-community.github.io/helm-charts"

--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -187,7 +187,7 @@ module "monitoring" {
     "sunyj1225@gmail.com",
     "oosuoos@gmail.com"
   ]
-  
+
   eks_oidc_provider_arn = module.eks.oidc_provider_arn
   eks_oidc_provider_url = module.eks.oidc_provider_url
 
@@ -200,11 +200,11 @@ module "monitoring" {
 # ─────────────────────────────
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = module.eks.cluster_endpoint
     cluster_ca_certificate = base64decode(module.eks.cluster_ca_data)
 
-    exec {
+    exec = {
       api_version = "client.authentication.k8s.io/v1beta1"
       command     = "aws"
       args        = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]

--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -187,6 +187,12 @@ module "monitoring" {
     "sunyj1225@gmail.com",
     "oosuoos@gmail.com"
   ]
+  
+  eks_oidc_provider_arn = module.eks.oidc_provider_arn
+  eks_oidc_provider_url = module.eks.oidc_provider_url
+
+  grafana_service_account_name      = "grafana"
+  grafana_service_account_namespace = "monitoring"
 }
 
 # ─────────────────────────────

--- a/envs/dev/provider.tf
+++ b/envs/dev/provider.tf
@@ -1,3 +1,29 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.5.0"
+    }
+  }
+}
+
 provider "aws" {
   region = "ap-northeast-2"
+}
+
+provider "helm" {
+  kubernetes = {
+    host                   = module.eks.cluster_endpoint
+    cluster_ca_certificate = base64decode(module.eks.cluster_ca_data)
+
+    exec = {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      command     = "aws"
+      args        = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
+    }
+  }
 }

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -35,3 +35,9 @@ resource "aws_eks_node_group" "default" {
     Name = "${var.cluster_name}-ng"
   }
 }
+
+resource "aws_iam_openid_connect_provider" "eks" {
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["9e99a48a9960b14926bb7f3b02e22da0c0e66e9a"]
+  url             = aws_eks_cluster.this.identity[0].oidc[0].issuer
+}

--- a/modules/eks/outputs.tf
+++ b/modules/eks/outputs.tf
@@ -9,3 +9,11 @@ output "cluster_endpoint" {
 output "cluster_ca_data" {
   value = aws_eks_cluster.this.certificate_authority[0].data
 }
+
+output "oidc_provider_arn" {
+  value = aws_iam_openid_connect_provider.eks.arn
+}
+
+output "oidc_provider_url" {
+  value = aws_iam_openid_connect_provider.eks.url
+}

--- a/modules/monitoring/grafana-values.tpl.yaml
+++ b/modules/monitoring/grafana-values.tpl.yaml
@@ -1,3 +1,18 @@
+# CloudWatch Datasource 정의 추가
+datasources:
+  datasources.yaml:
+    apiVersion: 1
+    datasources:
+      - name: CloudWatch
+        uid: CloudWatch
+        type: cloudwatch
+        access: proxy
+        isDefault: true
+        jsonData:
+          authType: ec2_iam_role
+          defaultRegion: ${region}
+
+# 대시보드 자동 로드 및 패널 정의
 dashboardProviders:
   dashboardproviders.yaml:
     apiVersion: 1

--- a/modules/monitoring/grafana_role.tf
+++ b/modules/monitoring/grafana_role.tf
@@ -1,0 +1,69 @@
+# IAM 정책 정의 (jsonencode 사용)
+resource "aws_iam_policy" "grafana_cloudwatch" {
+  name        = "grafana-cloudwatch-policy"
+  description = "Policy for Grafana to access CloudWatch and CloudWatch Logs"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "cloudwatch:ListMetrics",
+          "cloudwatch:GetMetricData",
+          "cloudwatch:GetMetricStatistics",
+          "cloudwatch:DescribeAlarms",
+          "cloudwatch:GetDashboard",
+          "logs:DescribeLogGroups",
+          "logs:DescribeLogStreams",
+          "logs:GetLogEvents",
+          "logs:StartQuery",
+          "logs:StopQuery",
+          "logs:GetQueryResults",
+          "logs:FilterLogEvents"
+        ],
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+# IRSA용 IAM 역할 생성
+resource "aws_iam_role" "grafana_irsa" {
+  name = "eks-irsa-grafana"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Federated = var.eks_oidc_provider_arn
+        },
+        Action = "sts:AssumeRoleWithWebIdentity",
+        Condition = {
+          StringEquals = {
+            "${replace(var.eks_oidc_provider_url, "https://", "")}:sub" = "system:serviceaccount:${var.grafana_service_account_namespace}:${var.grafana_service_account_name}"
+          }
+        }
+      }
+    ]
+  })
+}
+
+# 정책과 역할 연결
+resource "aws_iam_role_policy_attachment" "grafana_attach" {
+  role       = aws_iam_role.grafana_irsa.name
+  policy_arn = aws_iam_policy.grafana_cloudwatch.arn
+}
+
+# Grafana ServiceAccount (Helm과 연동하려면 이 이름 지정 필요)
+resource "kubernetes_service_account" "grafana" {
+  metadata {
+    name      = var.grafana_service_account_name
+    namespace = var.grafana_service_account_namespace
+    annotations = {
+      "eks.amazonaws.com/role-arn" = aws_iam_role.grafana_irsa.arn
+    }
+  }
+}

--- a/modules/monitoring/main.tf
+++ b/modules/monitoring/main.tf
@@ -32,6 +32,16 @@ resource "helm_release" "grafana" {
     name  = "service.type"
     value = "ClusterIP"
   }
+
+  set {
+    name  = "serviceAccount.name"
+    value = var.grafana_service_account_name
+  }
+
+  set {
+    name  = "serviceAccount.create"
+    value = "false"
+  }
 }
 
 # --------------------

--- a/modules/monitoring/main.tf
+++ b/modules/monitoring/main.tf
@@ -14,6 +14,8 @@ locals {
 }
 
 resource "helm_release" "grafana" {
+  provider = helm
+
   name             = "grafana-monitoring"
   repository       = "https://grafana.github.io/helm-charts"
   chart            = "grafana"
@@ -23,25 +25,24 @@ resource "helm_release" "grafana" {
 
   values = [ local.grafana_values ]
 
-  set {
-    name  = "adminPassword"
-    value = var.grafana_admin_password
-  }
-
-  set {
-    name  = "service.type"
-    value = "ClusterIP"
-  }
-
-  set {
-    name  = "serviceAccount.name"
-    value = var.grafana_service_account_name
-  }
-
-  set {
-    name  = "serviceAccount.create"
-    value = "false"
-  }
+  set = [
+    {
+      name  = "adminPassword"
+      value = var.grafana_admin_password
+    },
+    {
+      name  = "service.type"
+      value = "ClusterIP"
+    },
+    {
+      name  = "serviceAccount.name"
+      value = var.grafana_service_account_name
+    },
+    {
+      name  = "serviceAccount.create"
+      value = "false"
+    }
+  ]
 }
 
 # --------------------

--- a/modules/monitoring/variables.tf
+++ b/modules/monitoring/variables.tf
@@ -24,3 +24,21 @@ variable "grafana_admin_password" {
   type        = string
   default     = ""
 }
+
+variable "grafana_service_account_namespace" {
+  type    = string
+  default = "monitoring"
+}
+
+variable "grafana_service_account_name" {
+  type    = string
+  default = "grafana"
+}
+
+variable "eks_oidc_provider_arn" {
+  type = string
+}
+
+variable "eks_oidc_provider_url" {
+  type = string
+}


### PR DESCRIPTION
- EKS 모듈에 aws_iam_openid_connect_provider 리소스 추가 및 oidc_provider_arn/url 출력 정의
- monitoring 모듈에 eks_oidc_provider_arn/url, grafana_service_account_* 변수 추가
- Grafana Helm 차트에 IRSA용 ServiceAccount 주입 설정 (create=false, name=grafana)
- grafana-values.tpl.yaml에 CloudWatch datasource 정의 및 region 변수 반영