### PR TITLE
fix(monitoring): kubelet.json 대시보드 템플릿 들여쓰기 적용하여 YAML 파싱 오류 해결

### DIFF
--- a/modules/monitoring/grafana-values.tpl.yaml
+++ b/modules/monitoring/grafana-values.tpl.yaml
@@ -134,4 +134,4 @@ dashboards:
         }
     kubelet-dashboard:
       json: |
-        ${kubelet_json}
+        {{ indent 8 kubelet_json }}

--- a/modules/monitoring/main.tf
+++ b/modules/monitoring/main.tf
@@ -12,7 +12,7 @@ locals {
       sending_news = var.lambda_function_names["sending_news"]
       crawler      = var.lambda_function_names["crawler"]
     }
-    kubelet_json = local.kubelet_dashboard_json
+    kubelet_json = indent(8, local.kubelet_dashboard_json)
   })
 }
 


### PR DESCRIPTION
- kubelet.json 내용을 grafana-values.tpl.yaml에 삽입 시 indent(8, ...) 적용
- Helm 차트 적용 시 YAML → JSON 변환 오류 방지
- 잘못된 멀티라인 문자열로 인해 발생하던 Grafana 대시보드 로드 실패 해결