### PR TITLE
fix: kubelet 대시보드 JSON 포맷 문제 수정

### DIFF
--- a/modules/monitoring/grafana-values.tpl.yaml
+++ b/modules/monitoring/grafana-values.tpl.yaml
@@ -134,4 +134,4 @@ dashboards:
         }
     kubelet-dashboard:
       json: |
-        {{ indent 8 kubelet_json }}
+        ${kubelet_json}

--- a/modules/monitoring/main.tf
+++ b/modules/monitoring/main.tf
@@ -3,7 +3,7 @@
 # --------------------
 
 locals {
-  kubelet_dashboard_json = file("${path.module}/grafana_dashboard/kubelet.json")
+  kubelet_dashboard_json = jsonencode(jsondecode(file("${path.module}/grafana_dashboard/kubelet.json")))
 
   grafana_values = templatefile("${path.module}/grafana-values.tpl.yaml", {
     region = var.region
@@ -12,7 +12,7 @@ locals {
       sending_news = var.lambda_function_names["sending_news"]
       crawler      = var.lambda_function_names["crawler"]
     }
-    kubelet_json = indent(8, local.kubelet_dashboard_json)
+    kubelet_json = local.kubelet_dashboard_json
   })
 }
 


### PR DESCRIPTION
- Terraform에서 대시보드 JSON 파일을 직접 읽어올 때 인코딩 오류로 ConfigMap에 적용되지 않는 문제 수정
- file() → jsondecode() → jsonencode() 방식으로 JSON 포맷 안전하게 처리
- grafana-values 템플릿에서는 indent 제거하고 ${kubelet_json} 직접 삽입으로 변경