### PR TITLE
feat: Grafana에 Prometheus 데이터 소스 추가

### DIFF
--- a/modules/monitoring/grafana-values.tpl.yaml
+++ b/modules/monitoring/grafana-values.tpl.yaml
@@ -1,4 +1,4 @@
-# CloudWatch Datasource 정의 추가
+# CloudWatch + Prometheus Datasource 정의
 datasources:
   datasources.yaml:
     apiVersion: 1
@@ -11,6 +11,12 @@ datasources:
         jsonData:
           authType: ec2_iam_role
           defaultRegion: ap-northeast-2
+      - name: Prometheus
+        uid: prometheus
+        type: prometheus
+        access: proxy
+        url: http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090
+        isDefault: false
 
 # 대시보드 자동 로드 및 패널 정의
 dashboardProviders:


### PR DESCRIPTION
- CloudWatch 외에 Prometheus도 datasource로 추가
- URL은 서비스 이름 기준 클러스터 내부 DNS 사용
- 기본값은 유지하고 uid는 prometheus로 지정