### PR TITLE
feat(grafana): migrate legacy graph panels to React and set timezone …

### DIFF
--- a/modules/monitoring/grafana_dashboard/kubelet.json
+++ b/modules/monitoring/grafana_dashboard/kubelet.json
@@ -250,7 +250,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "mode": "time",
         "show": true,
@@ -336,7 +336,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "mode": "time",
         "show": true,
@@ -422,7 +422,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "mode": "time",
         "show": true,
@@ -556,7 +556,7 @@
       "30d"
     ]
   },
-  "timezone": "utc",
+  "timezone": "Asia/Seoul",
   "title": "Kubernetes / Kubelet",
   "uid": "3138fa155d5915769fbded898ac09fd9",
   "version": 1,


### PR DESCRIPTION
…to Asia/Seoul

- converted deprecated "graph" panels to "timeseries" (React-based)
- changed dashboard timezone from "utc" to "Asia/Seoul"
- intended to improve compatibility with future Grafana versions