### PR TITLE
fix: IRSA 환경에서 CloudWatch 연결 실패 문제 해결

### DIFF
--- a/modules/monitoring/grafana-values.tpl.yaml
+++ b/modules/monitoring/grafana-values.tpl.yaml
@@ -9,7 +9,6 @@ datasources:
         access: proxy
         isDefault: true
         jsonData:
-          authType: ec2_iam_role
           defaultRegion: ap-northeast-2
       - name: Prometheus
         uid: prometheus


### PR DESCRIPTION
- Grafana CloudWatch datasource의 authType 설정 제거
- ec2_iam_role은 IRSA(WebIdentity)와 호환되지 않기 때문에 생략 처리
- CloudWatch 데이터소스가 정상 인식되도록 수정