### PR TITLE
fix(monitoring): ensure Grafana namespace and RBAC for Helm release

### DIFF
--- a/modules/monitoring/grafana_role.tf
+++ b/modules/monitoring/grafana_role.tf
@@ -61,6 +61,12 @@ resource "aws_iam_role_policy_attachment" "grafana_attach" {
   policy_arn = aws_iam_policy.grafana_cloudwatch.arn
 }
 
+resource "kubernetes_namespace" "monitoring" {
+  metadata {
+    name = var.grafana_service_account_namespace
+  }
+}
+
 # Grafana ServiceAccount (Helm과 연동하려면 이 이름 지정 필요)
 resource "kubernetes_service_account" "grafana" {
   provider = kubernetes
@@ -72,4 +78,6 @@ resource "kubernetes_service_account" "grafana" {
       "eks.amazonaws.com/role-arn" = aws_iam_role.grafana_irsa.arn
     }
   }
+
+  depends_on = [kubernetes_namespace.monitoring]
 }

--- a/modules/monitoring/main.tf
+++ b/modules/monitoring/main.tf
@@ -30,22 +30,32 @@ resource "helm_release" "grafana" {
 
   set = [
     {
-    name  = "adminPassword"
-    value = var.grafana_admin_password
+      name  = "adminPassword"
+      value = var.grafana_admin_password
     },
     {
-    name  = "service.type"
-    value = "ClusterIP"
+      name  = "service.type"
+      value = "ClusterIP"
     },
     {
-    name  = "serviceAccount.name"
-    value = var.grafana_service_account_name
+      name  = "serviceAccount.name"
+      value = kubernetes_service_account.grafana.metadata[0].name
     },
     {
-    name  = "serviceAccount.create"
-    value = "false"
+      name  = "serviceAccount.create"
+      value = "false"
+    },
+    {
+      name  = "rbac.create"
+      value = "true"
+    },
+    {
+      name  = "datasources.datasource.yaml.apiVersion"
+      value = "1"
     }
   ]
+
+  depends_on = [kubernetes_namespace.monitoring]
 }
 
 # --------------------


### PR DESCRIPTION
- 추가: kubernetes_namespace.monitoring 리소스 정의
- 수정: Helm release가 namespace 생성 후 실행되도록 depends_on 추가
- 수정: serviceAccount 이름을 변수 → 참조 방식으로 변경
- 추가: rbac.create 및 datasource apiVersion Helm 설정 추가
- 해결: Helm 릴리스 재사용 불가 및 네임스페이스 미존재 오류 대응