### PR TITLE
feat: add reduceOptions and fieldConfig to CloudWatch stat panels

### DIFF
--- a/modules/monitoring/grafana-values.tpl.yaml
+++ b/modules/monitoring/grafana-values.tpl.yaml
@@ -72,7 +72,26 @@ dashboards:
                   "period": 60,
                   "refId": "RDS_CPU"
                 }
-              ]
+              ],
+              "options": {
+                "reduceOptions": {
+                  "values": false,
+                  "calcs": ["lastNotNull"],
+                  "fields": "Numeric Fields"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      { "value": null, "color": "green" },
+                      { "value": 80, "color": "red" }
+                    ]
+                  }
+                },
+                "overrides": []
+              }
             },
             {
               "type": "stat",
@@ -88,7 +107,26 @@ dashboards:
                   "period": 60,
                   "refId": "RDS_Conn"
                 }
-              ]
+              ],
+              "options": {
+                "reduceOptions": {
+                  "values": false,
+                  "calcs": ["lastNotNull"],
+                  "fields": "Numeric Fields"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      { "value": null, "color": "green" },
+                      { "value": 1000, "color": "red" }
+                    ]
+                  }
+                },
+                "overrides": []
+              }
             },
             {
               "type": "stat",
@@ -100,7 +138,26 @@ dashboards:
                   "refId": "MailOK_sending",
                   "region": "ap-northeast-2"
                 }
-              ]
+              ],
+              "options": {
+                "reduceOptions": {
+                  "values": false,
+                  "calcs": ["lastNotNull"],
+                  "fields": "Numeric Fields"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      { "value": null, "color": "green" },
+                      { "value": 1, "color": "red" }
+                    ]
+                  }
+                },
+                "overrides": []
+              }
             },
             {
               "type": "stat",
@@ -112,7 +169,26 @@ dashboards:
                   "refId": "MailErr_sending",
                   "region": "ap-northeast-2"
                 }
-              ]
+              ],
+              "options": {
+                "reduceOptions": {
+                  "values": false,
+                  "calcs": ["lastNotNull"],
+                  "fields": "Numeric Fields"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      { "value": null, "color": "green" },
+                      { "value": 1, "color": "red" }
+                    ]
+                  }
+                },
+                "overrides": []
+              }
             },
             {
               "type": "stat",
@@ -128,7 +204,26 @@ dashboards:
                   "period": 60,
                   "refId": "LambdaErr_crawler"
                 }
-              ]
+              ],
+              "options": {
+                "reduceOptions": {
+                  "values": false,
+                  "calcs": ["lastNotNull"],
+                  "fields": "Numeric Fields"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      { "value": null, "color": "green" },
+                      { "value": 1, "color": "red" }
+                    ]
+                  }
+                },
+                "overrides": []
+              }
             },
             {
               "type": "stat",
@@ -140,7 +235,26 @@ dashboards:
                   "refId": "CrawlOK",
                   "region": "ap-northeast-2"
                 }
-              ]
+              ],
+              "options": {
+                "reduceOptions": {
+                  "values": false,
+                  "calcs": ["lastNotNull"],
+                  "fields": "Numeric Fields"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      { "value": null, "color": "green" },
+                      { "value": 1, "color": "red" }
+                    ]
+                  }
+                },
+                "overrides": []
+              }
             },
             {
               "type": "stat",
@@ -152,10 +266,30 @@ dashboards:
                   "refId": "CrawlDel",
                   "region": "ap-northeast-2"
                 }
-              ]
+              ],
+              "options": {
+                "reduceOptions": {
+                  "values": false,
+                  "calcs": ["lastNotNull"],
+                  "fields": "Numeric Fields"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      { "value": null, "color": "green" },
+                      { "value": 1, "color": "red" }
+                    ]
+                  }
+                },
+                "overrides": []
+              }
             }
           ]
         }
+
     kubelet-dashboard:
       json: |
         ${kubelet_json}


### PR DESCRIPTION
- RDS CPUUtilization, DatabaseConnections, Lambda Errors 등 모든 stat 패널에 reduceOptions 및 fieldConfig 설정 추가
- "No data" 표시 문제 해결 및 시각적 threshold 지정
- CloudWatch 패널에서 마지막 유효 값(lastNotNull) 기준으로 단일 값 계산