### PR TITLE
feat: ECR 라이프사이클 정책 수정 (태그 3개 보존 + 1일 지난 untagged 삭제)

### DIFF
--- a/modules/eks/lifecycle.tf
+++ b/modules/eks/lifecycle.tf
@@ -5,12 +5,25 @@ resource "aws_ecr_lifecycle_policy" "spring_app" {
     rules = [
       {
         rulePriority = 1
-        description  = "Delete untagged images older than 1 days"
+        description  = "최신 3개 태그만 보존"
+        selection = {
+          tagStatus     = "tagged"
+          tagPrefixList = ["v1.0."]
+          countType     = "imageCountMoreThan"
+          countNumber   = 3
+        }
+        action = {
+          type = "expire"
+        }
+      },
+      {
+        rulePriority = 2
+        description  = "1일 지난 untagged 삭제"
         selection = {
           tagStatus     = "untagged"
           countType     = "sinceImagePushed"
-          countUnit     = "days"
           countNumber   = 1
+          countUnit     = "days"
         }
         action = {
           type = "expire"


### PR DESCRIPTION
- v1.0.* 형식의 태그가 붙은 이미지는 최신 3개만 보존
- 태그 없는 이미지는 푸시된 지 1일 경과 시 삭제