### PR TITLE
fix: CloudWatch 로그 필터에서 대소문자 구분으로 인해 메일 실패 로그가 표시되지 않던 문제 수정

### DIFF
--- a/modules/monitoring/grafana_dashboard/cloudwatch.json
+++ b/modules/monitoring/grafana_dashboard/cloudwatch.json
@@ -210,7 +210,7 @@
             "uid": "CloudWatch"
           },
           "dimensions": {},
-          "expression": "fields @timestamp, @message\n| filter @message like /fail/\n| sort @timestamp desc\n| limit 20\n",
+          "expression": "fields @timestamp, @message\n| filter @message like /Fail/\n| sort @timestamp desc\n| limit 20\n",
           "id": "",
           "label": "",
           "logGroups": [


### PR DESCRIPTION
- 필터 표현식 내 fail을 Fail로 수정하여 로그 검색 가능하도록 변경